### PR TITLE
Supported multiple categories groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ This is a custom iOS widget for [Actual Budget](https://actualbudget.org), built
 const syncId = "YOUR_SYNC_ID"
 const apiKey = "YOUR_API_KEY"
 const apiBaseUrl = "https://your-actual-api.example.com"
-const targetGroupName = "Category Group Title"
+const targetGroupNames = [
+  // If there is only one group remove the comma at the end. Basically always a comma except for the last entry
+  // The ios widgets are not scrollable. If the categories are many it could be necessary to change the font size and spacing and/or create multiple widgets
+  "",
+  ""
+]
 ```
 
 4.	**Optional: Customize appearance** (currency, fonts, colors, spacing).

--- a/actual-budget-widget.js
+++ b/actual-budget-widget.js
@@ -1,24 +1,28 @@
 // === 📦 CONFIGURATION VARIABLES ===
 
-// 🔑 Your Actual Budget sync ID (Settings → Advanced → Sync ID)
+// 🔑 Your Actual Budget sync ID (Settings → Advanced → Sync ID) (change)
 const syncId = "YOUR_SYNC_ID"
 
-// 🔐 API key set in your actual-http-api server (must match the `API_KEY` env variable)
+// 🔐 API key set in your actual-http-api server (must match the `API_KEY` env variable) (change)
 const apiKey = "YOUR_API_KEY"
 
-// 🌐 Base URL of your actual-http-api instance (no trailing slash)
+// 🌐 Base URL of your actual-http-api instance (no trailing slash) (change)
 const apiBaseUrl = "https://your-actual-api.example.com"
 
 // 📁 Name of the category group to display in the widget
-const targetGroupName = "Category Group Title"
+const targetGroupNames = [
+  "Monthly Bills",
+  "Living Expenses",
+  "Fun Money" 
+]
 
-// 💸 Currency formatting
+// 💸 Currency formatting (change if needed)
 const currencyPrefix = "$"  // Symbol shown before the number
 const currencySuffix = ""   // Text shown after the number
 
 // === 🎨 APPEARANCE SETTINGS ===
 
-// Font sizes
+// ⚠ Font sizes (change if needed)
 const textSize = 16                         // Category name
 const balanceSize = 16                      // Category balance
 const groupTitleSize = 12                   // Title line
@@ -169,17 +173,25 @@ if (enableDebugLogging) {
 
 // === 📂 Display category group
 const groups = data.data
-const targetGroup = groups.find(g => g.name === targetGroupName)
 
-if (!targetGroup) {
-  w.addText(`❌ Group '${targetGroupName}' not found`)
-} else {
-  const title = w.addText(`${prettyMonth} • ${targetGroup.name}`)
+for (const groupName of targetGroupNames) {
+  const targetGroup = groups.find(g => g.name === groupName)
+
+  if (!targetGroup) {
+    const err = w.addText(`❌ Group '${groupName}' not found`)
+    err.textColor = Color.red()
+    w.addSpacer(12)
+    continue
+  }
+
+  const title = w.addText(`${targetGroup.name}`)
   title.font = Font.boldSystemFont(groupTitleSize)
   title.textColor = groupTitleColor
-  w.addSpacer(12)
+  w.addSpacer(4)
 
   for (const cat of targetGroup.categories) {
+    if (cat.hidden || cat.balance === 0) continue 
+
     const stack = w.addStack()
     stack.layoutHorizontally()
     stack.centerAlignContent()
@@ -199,6 +211,8 @@ if (!targetGroup) {
 
     w.addSpacer(itemSpacing)
   }
+  
+  w.addSpacer(12)
 }
 
 // === 📦 Insert uncategorised transaction box (if applicable)

--- a/actual-budget-widget.js
+++ b/actual-budget-widget.js
@@ -9,7 +9,7 @@ const apiKey = "YOUR_API_KEY"
 // 🌐 Base URL of your actual-http-api instance (no trailing slash) (change)
 const apiBaseUrl = "https://your-actual-api.example.com"
 
-// 📁 Name of the category group to display in the widget
+// 📁 Name of the category group to display in the widget (change)
 const targetGroupNames = [
   "Monthly Bills",
   "Living Expenses",


### PR DESCRIPTION
A user can easily change the targetGroupNames const block to support multiple groups

For example: 
`const targetGroupNames = [
  "Monthly Bills",
  "Living Expenses",
  "Fun Money" 
]`

Note:
- The ios widget have a fixed width. If the category has too many transaction the only way to fix it is to either
    - Create another widget
    - Reduce font size and/or gap 